### PR TITLE
Fix CSS Conflicts - Card Summaries

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -15,15 +15,8 @@
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
 
-
-    <!-- Argon -->
     <!-- Fonts -->
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,600,700" rel="stylesheet">
-    <!-- Icons -->
-    <!--<link href="../src/argon/assets/vendor/nucleo/css/nucleo.css" rel="stylesheet">-->
-    <!--<link href="../src/argon/assets/vendor/font-awesome/css/font-awesome.min.css" rel="stylesheet">-->
-    <!-- Argon CSS -->
-    <!--<link type="text/css" href="../src/argon/assets/css/argon.css" rel="stylesheet">-->
 
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.

--- a/frontend/src/components/Footer/Footer.css
+++ b/frontend/src/components/Footer/Footer.css
@@ -3,7 +3,3 @@
   background-color: rgba(15, 15, 45, 1);
   color:white;
 }
-
-.Footer p {
-  font-size: 12pt;
-}

--- a/frontend/src/components/Home/Home.css
+++ b/frontend/src/components/Home/Home.css
@@ -15,13 +15,9 @@ font-weight: 300;
   font-weight: 300;
 }
 
-.column { 
-  float: left; 
-  width: 27%; 
-  height: 300px;  
+.column {
+  float: left;
+  width: 27%;
+  height: 300px;
   background-color: orange;
-} 
-p { 
-  font-size:20px; 
-  font-weight:bold; 
-} 
+}

--- a/frontend/src/components/Layout/HeadNav/HeadNav.js
+++ b/frontend/src/components/Layout/HeadNav/HeadNav.js
@@ -14,7 +14,7 @@ class HeadNav extends Component {
 
   render() {
     return (
-      <Navbar variant="dark" className="HeadNav">
+      <Navbar fixed variant="dark" className="HeadNav">
         <Navbar.Brand href="/">Kalamazoo College Mathematics</Navbar.Brand>
         <Nav className="ml-auto">
           <Nav.Link href="/home">Login</Nav.Link>


### PR DESCRIPTION
# Description

Corrects CSS conflict created from lack of class name

## How Has This Been Tested?

Cards now appear as they did before with thin (normal) text and smaller font
